### PR TITLE
Add font defaults and remove defining font name everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@vitejs/plugin-react": "^2.1.0",
     "sass": "^1.63.6",
     "typescript": "5.0.4",
+    "unplugin-fonts": "^1.0.3",
     "vite": "^3.1.0",
     "vite-plugin-svgr": "^3.2.0"
   }

--- a/src/Pages/Auction/components/amount-input/AmountInput.scss
+++ b/src/Pages/Auction/components/amount-input/AmountInput.scss
@@ -11,7 +11,6 @@
 
     &_error-text {
         color: #FF6871;
-        font-family: Nunito-Sans-Regular !important;
         font-size: 0.825rem !important;
         font-style: normal;
         line-height: normal;
@@ -27,7 +26,6 @@
         &_text {
             color: #373737;
             text-align: justify;
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.875em !important;
             font-style: normal !important;
             line-height: normal !important;
@@ -43,7 +41,7 @@
         &_text {
             color: #5940C1;
             text-align: justify;
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
             font-size: 1.75em !important;
             font-style: normal;
             line-height: normal;
@@ -65,7 +63,6 @@
         &_text {
             color: #373737;
             text-align: center;
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.875em !important;
             font-style: normal;
             font-weight: 400;
@@ -84,7 +81,6 @@
         &_text-unlock {
             color: #5940C1;
             text-align: center;
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.875em !important;
             font-style: normal;
             font-weight: 400;

--- a/src/Pages/Auction/components/auction-info/AuctionInfo.scss
+++ b/src/Pages/Auction/components/auction-info/AuctionInfo.scss
@@ -4,7 +4,7 @@
 
     &_header {
         color: #180B2D;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 0.875em !important;
         font-style: normal !important;
         line-height: normal !important;
@@ -24,7 +24,6 @@
         &_heading {
             color: #373737;
             text-align: justify;
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.875em !important;
             font-style: normal;
             line-height: normal;
@@ -36,7 +35,7 @@
 
         &_subHeading {
             color: #000;
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
             font-size: 0.875em !important;
             font-style: normal;
             line-height: normal;

--- a/src/Pages/Auction/components/auction-status/AuctionStatus.tsx
+++ b/src/Pages/Auction/components/auction-status/AuctionStatus.tsx
@@ -15,27 +15,27 @@ const getLabelAndColor = (
   if (auctionState === AuctionState.ORDER_PLACING || AuctionState.ORDER_PLACING_AND_CANCELING) {
     return {
       label: 'In Progress',
-      color: '#0DD36B',
+      color: 'success.main',
     }
   }
 
   if (auctionState === AuctionState.CLAIMING) {
     return {
       label: 'Completed',
-      color: '#E5E1FC',
+      color: 'success.dark',
     }
   }
 
   if (auctionState === AuctionState.NOT_YET_STARTED) {
     return {
       label: 'Not Yet Started',
-      color: '#FFDADA',
+      color: 'secondary.light',
     }
   }
 
   return {
     label: 'Error',
-    color: '#FFDADA',
+    color: 'error.light',
   }
 }
 
@@ -48,8 +48,8 @@ const AuctionStatus: React.FC<AuctionStatusProps> = ({ auctionState }) => {
       sx={{
         backgroundColor: color,
         '& .MuiChip-label': {
-          color: '#180B2D',
-          fontFamily: 'Nunito-Sans-Bold !important',
+          color: 'primary.dark',
+          fontWeight: 700,
         },
         '& .MuiChip-root': {
           borderRadius: '5px !important',

--- a/src/Pages/Auction/components/auction_details/AuctionDetails.scss
+++ b/src/Pages/Auction/components/auction_details/AuctionDetails.scss
@@ -12,15 +12,14 @@
   &_headerText {
     margin: 0 0 0 1em;
     &_heading {
-      font-family: Nunito-Sans-Bold !important;
+      font-weight: 700 !important;
       word-spacing: 0.5px !important;
       font-size: 1.75em !important;
     }
 
     &_link {
       color: #5940c1;
-      font-family: Nunito Sans;
-      font-size: 0.875em;
+      font-size: 0.875em !important;
       font-style: normal;
       font-weight: 400;
       line-height: normal;
@@ -31,7 +30,6 @@
   &_summary {
     color: #373737 !important;
     text-align: justify;
-    font-family: Nunito-Sans-Regular !important;
     font-size: 0.825rem !important;
     font-style: normal;
     line-height: normal;
@@ -43,19 +41,15 @@
     border: none !important;
     border-radius: 0.5em !important;
 
-    &_content {
-      font-family: Nunito-Sans-Regular !important;
-    }
-
     &_title {
-      font-family: Nunito-Sans-Bold !important;
+      font-weight: 700 !important;
     }
   }
 
   &_timer {
     color: #5940c1;
     text-align: justify;
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
     font-style: normal;
     line-height: normal;
   }
@@ -75,6 +69,6 @@
 
 .auctionDetails-timer {
   color: #5940c1 !important;
-  font-family: Nunito-Sans-Bold !important;
+  font-weight: 700 !important;
   font-size: 1.75rem !important;
 }

--- a/src/Pages/Auction/components/auction_details/AuctionDetails.tsx
+++ b/src/Pages/Auction/components/auction_details/AuctionDetails.tsx
@@ -129,17 +129,18 @@ const AuctionDetails: React.FC = () => {
             size="small"
             sx={{
               paddingLeft: '0.3rem',
+              bgcolor: 'primary.dark',
             }}
           />
           {isPrivateAuction && (
             <Chip
+              color="secondary"
               icon={<Lock />}
               label="Private Auction"
               size="small"
               sx={{
                 paddingLeft: '0.2rem',
                 marginLeft: '1rem',
-                backgroundColor: '#FFC82E',
               }}
             />
           )}

--- a/src/Pages/Auction/components/cancel-order-modal-footer/CancelOrderModalFooter.scss
+++ b/src/Pages/Auction/components/cancel-order-modal-footer/CancelOrderModalFooter.scss
@@ -16,7 +16,6 @@
 
     &_text {
       color: #000;
-      font-family: Nunito-Sans-Regular !important;
       font-size: 0.75rem !important;
       font-style: normal;
       line-height: normal;
@@ -45,7 +44,7 @@
     padding: 0.75rem 2rem;
     color: #fff;
     text-align: center;
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
     font-size: 0.875rem !important;
     font-style: normal;
     line-height: normal;

--- a/src/Pages/Auction/components/claim-order-modal-footer/ClaimOrderModalFooter.scss
+++ b/src/Pages/Auction/components/claim-order-modal-footer/ClaimOrderModalFooter.scss
@@ -7,7 +7,6 @@
 
     &_text {
       color: #000;
-      font-family: Nunito-Sans-Regular !important;
       font-size: 0.75rem !important;
       font-style: normal;
       line-height: normal;
@@ -32,7 +31,7 @@
     padding: 0.75rem 2rem;
     color: #fff;
     text-align: center;
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
     font-size: 0.875rem !important;
     font-style: normal;
     line-height: normal;

--- a/src/Pages/Auction/components/claimer/Claimer.scss
+++ b/src/Pages/Auction/components/claimer/Claimer.scss
@@ -5,7 +5,7 @@
   
     &_header {
       color: #180b2d !important;
-      font-family: Nunito-Sans-Bold !important;
+      font-weight: 700 !important;
       font-size: 0.875em !important;
       font-style: normal !important;
       line-height: normal !important;
@@ -18,7 +18,6 @@
   
     &_subheader {
       color: #000 !important;
-      font-family: Nunito-Sans-Regular !important;
       font-size: 0.875em !important;
       font-style: normal !important;
       line-height: normal !important;

--- a/src/Pages/Auction/components/confirmation-modal/ConfirmationModal.scss
+++ b/src/Pages/Auction/components/confirmation-modal/ConfirmationModal.scss
@@ -13,7 +13,7 @@
 
   &_header {
     color: #180b2d;
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
     font-size: 0.875em !important;
     font-style: normal !important;
     line-height: normal !important;
@@ -30,7 +30,6 @@
   &_wallet-confirm {
     color: #222;
     text-align: right !important;
-    font-family: Nunito-Sans-Regular !important;
     font-size: 0.75rem !important;
     font-style: normal !important;
     line-height: normal;
@@ -43,7 +42,7 @@
     padding: 0.75rem 2rem;
     color: #fff;
     text-align: center;
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
     font-size: 0.875rem !important;
     font-style: normal;
     line-height: normal;
@@ -67,7 +66,7 @@
         margin-top: 1rem !important;
         color: #180B2D;
         text-align: center;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 0.825rem !important;
         font-style: normal;
         line-height: normal;
@@ -77,7 +76,6 @@
     &_link {
         color: #373737;
         text-align: center;
-        font-family: Nunito-Sans-Regular !important;
         font-size: 0.825rem !important;
         font-style: normal;
         line-height: normal;

--- a/src/Pages/Auction/components/general-information/GeneralInfo.scss
+++ b/src/Pages/Auction/components/general-information/GeneralInfo.scss
@@ -1,7 +1,7 @@
 .general-info {
     &_header {
         color: #180B2D;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 0.875em !important;
         font-style: normal !important;
         line-height: normal !important;
@@ -10,7 +10,6 @@
     &_body {
         color: #373737;
         text-align: justify;
-        font-family: Nunito-Sans-Regular !important;
         font-size: 0.875em !important;
         font-style: normal !important;
         line-height: normal;

--- a/src/Pages/Auction/components/order-placement/OrderPlacement.scss
+++ b/src/Pages/Auction/components/order-placement/OrderPlacement.scss
@@ -5,7 +5,7 @@
 
   &_header {
     color: #180b2d !important;
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
     font-size: 0.875em !important;
     font-style: normal !important;
     line-height: normal !important;
@@ -18,7 +18,6 @@
 
   &_subheader {
     color: #000 !important;
-    font-family: Nunito-Sans-Regular !important;
     font-size: 0.875em !important;
     font-style: normal !important;
     line-height: normal !important;
@@ -48,7 +47,6 @@
     align-items: center !important;
 
     &_text {
-      font-family: Nunito-Sans-Regular !important;
       font-size: 0.875em !important;
       font-style: normal !important;
       line-height: normal !important;

--- a/src/Pages/Auction/components/orderbook/Orderbook.scss
+++ b/src/Pages/Auction/components/orderbook/Orderbook.scss
@@ -5,7 +5,7 @@
 
     &_header {
         color: #180B2D;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 0.875em !important;
         font-style: normal !important;
         line-height: normal !important;

--- a/src/Pages/Auction/components/orders-table/OrdersTable.scss
+++ b/src/Pages/Auction/components/orders-table/OrdersTable.scss
@@ -1,17 +1,7 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
 .orders-table {
     &_header {
         color: #180B2D;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 0.875em !important;
         font-style: normal !important;
         line-height: normal !important;
@@ -31,14 +21,13 @@
         &_subheading {
             color: #373737;
             text-align: center;
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.875em !important;
             font-style: normal;
             line-height: normal;
             
 
             &_title {
-                font-family: Nunito-Sans-Bold !important;
+                font-weight: 700 !important;
                 padding-top: 1em;
             }
 

--- a/src/Pages/Auction/components/place-order-button/PlaceOrderButton.scss
+++ b/src/Pages/Auction/components/place-order-button/PlaceOrderButton.scss
@@ -18,7 +18,7 @@
     color: #fff;
     width: 50%;
     text-align: center;
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
     font-size: 0.875em !important;
     font-style: normal !important;
     line-height: normal;

--- a/src/Pages/Auction/components/place-order-modal-footer/PlaceOrderModalFooter.scss
+++ b/src/Pages/Auction/components/place-order-modal-footer/PlaceOrderModalFooter.scss
@@ -18,7 +18,6 @@
 
     &_text {
       color: #000;
-      font-family: Nunito-Sans-Regular !important;
       font-size: 0.75rem !important;
       font-style: normal;
       line-height: normal;
@@ -36,7 +35,6 @@
 
   &_warning {
     color: #5940C1;
-    font-family: Nunito-Sans-Regular !important;
     font-size: 0.75rem !important;
     font-style: normal;
     line-height: normal;

--- a/src/Pages/Auction/components/price-input/PriceInput.scss
+++ b/src/Pages/Auction/components/price-input/PriceInput.scss
@@ -11,7 +11,6 @@
 
     &_error-text {
         color: #FF6871;
-        font-family: Nunito-Sans-Regular !important;
         font-size: 0.825rem !important;
         font-style: normal;
         line-height: normal;
@@ -28,7 +27,6 @@
         &_text {
             color: #373737;
             text-align: justify;
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.875em !important;
             font-style: normal !important;
             line-height: normal !important;
@@ -44,7 +42,7 @@
         &_text {
             color: #5940C1;
             text-align: justify;
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
             font-size: 1.75em !important;
             font-style: normal;
             line-height: normal;

--- a/src/Pages/Auction/components/settle-auction-button/SettleAuctionButton.scss
+++ b/src/Pages/Auction/components/settle-auction-button/SettleAuctionButton.scss
@@ -18,7 +18,7 @@
     color: #fff;
     width: 50%;
     text-align: center;
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
     font-size: 0.875em !important;
     font-style: normal !important;
     line-height: normal;
@@ -44,7 +44,6 @@
 
   &_subtext {
     color: #000;
-    font-family: Nunito-Sans-Regular !important;
     font-size: 0.75em !important;
     font-style: normal !important;
     line-height: normal;

--- a/src/Pages/Auction/components/tab_selection/Tab.scss
+++ b/src/Pages/Auction/components/tab_selection/Tab.scss
@@ -1,10 +1,9 @@
 .tab {
-    font-family: Nunito-Sans-Regular, sans-serif;
     padding: 0.5em 1em !important;
     color: black;
     cursor: pointer;
     font-size: 0.875rem;
-    font-weight: 600;
+    font-weight: 600 !important;
     background-color: transparent;
     margin: 0.25em;
     border: none;

--- a/src/Pages/CreateAuction/index.scss
+++ b/src/Pages/CreateAuction/index.scss
@@ -1,13 +1,3 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
 .modal {
     @media only screen and (min-width: 960px) {
         display: flex;
@@ -22,7 +12,7 @@
         margin-bottom: 1em;
 
         &_text {
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
             font-size: 0.875rem !important;
             color: #000000 !important;
         }
@@ -41,19 +31,17 @@
         }
 
         &_heading {
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
             font-size: 1rem !important;
             margin-bottom: 0.5em !important;
         }
 
         &_title {
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.875rem !important;
             counter-reset: #000000 !important;
         }
 
         &_text {
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.875rem !important;
             margin-bottom: 0.5em !important;
             color: #373737 !important;
@@ -66,7 +54,7 @@
         border: solid #5940C1 1px;
         background-color: #5940C1;
         color: #FFFFFF;
-        font-family: Nunito-Sans-Bold;
+        font-weight: 700 !important;
         font-size: 0.875rem;
         width: fit-content;
         margin-left: auto;
@@ -81,7 +69,7 @@
     border: solid #5940C1 1px;
     background-color: #5940C1;
     color: #FFFFFF;
-    font-family: Nunito-Sans-Bold;
+    font-weight: 700 !important;
     font-size: 0.875rem;
     width: fit-content;
     margin-left: auto;
@@ -99,7 +87,6 @@
     &_input {
         color: #373737 !important;
         font-size: 0.875rem !important;
-        font-family: Nunito-Sans-Regular !important;
 
         &_wrapper {
             display: flex;
@@ -117,7 +104,7 @@
     }
 
     &_switch-title {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 0.875rem !important;
         display: flex !important;
         gap: 0.5em !important;
@@ -125,7 +112,7 @@
     }
 
     &_title {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 0.875rem !important;
         margin-bottom: 1.25em !important;
         display: flex !important;
@@ -133,7 +120,6 @@
     }
 
     &_text {
-        font-family: Nunito-Sans-Regular !important;
         font-size: 0.875rem !important;
         color: #373737 !important;
     }
@@ -150,8 +136,8 @@
         border-radius: 1em;
         border: solid #5940C1 1px;
         color: #5940C1;
-        font-family: Nunito-Sans-Bold;
-        font-size: 0.875rem;
+        font-weight: 700 !important;
+        font-size: 0.875rem !important;
         background-color: transparent;
         cursor: pointer;
     }
@@ -162,19 +148,18 @@
     margin-left: 1em;
 
     &_title {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 0.75rem !important;
         margin: 2em 0 !important;
     }
 
     &_item {
-        font-family: Nunito-Sans-Regular !important;
         font-size: 0.75rem !important;
         margin-bottom: 2em !important;
         color: #949494 !important;
 
         &_selected {
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
             color: #5940C1 !important;
             font-size: 0.75rem !important;
             margin-bottom: 2em !important;
@@ -198,12 +183,11 @@
         gap: 0.5em;
 
         &_section {
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.75rem !important;
         }
 
         &_title {
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
             font-size: 0.75rem !important;
             color: #5940C1 !important;
         }
@@ -225,7 +209,6 @@
     }
 
     &_section {
-        font-family: Nunito-Sans-Regular !important;
         font-size: 0.75rem !important;
         margin-top: 2em !important;
 

--- a/src/Pages/CreateAuction/index.tsx
+++ b/src/Pages/CreateAuction/index.tsx
@@ -167,7 +167,7 @@ const CreateAuction: React.FC = () => {
               documentation to gain a deeper understanding before finalizing any transactions.
             </Typography>
             <button className="content_button" onClick={navigateToDocs}>
-              Read the Docs
+              <Typography variant="inherit">Read the Docs</Typography>
             </button>
           </div>
           {/* Network */}

--- a/src/Pages/Docs/index.scss
+++ b/src/Pages/Docs/index.scss
@@ -1,13 +1,3 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
 .docs {
     background-color: #F2F1F9 !important;
 
@@ -17,12 +7,11 @@
         gap: 0.5em;
 
         &_category {
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.75rem !important;
         }
 
         &_title {
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 600 !important;
             font-size: 0.75rem !important;
             color: #5940C1 !important;
         }
@@ -51,7 +40,7 @@
     }
 
     &_category {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 0.75rem !important;
         margin-top: 2em !important;
 
@@ -61,7 +50,6 @@
     }
 
     &_item {
-        font-family: Nunito-Sans-regular !important;
         font-size: 0.75rem !important;
         margin: 1em 0 1em 1em !important;
         color: #949494 !important;
@@ -94,19 +82,18 @@
 
         &_category {
             margin: 1em 0 !important;
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
             font-size: 0.875rem !important;
             color: #5940C1 !important;
         }
 
         &_title {
             margin: 0 0 0.5em !important;
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
             font-size: 1.75rem !important;
         }
 
         &_text {
-            font-family: Nunito-Sans-Regular !important;
             font-size: 0.875rem !important;
             margin-top: 1em !important;
             max-width: fit-content !important;
@@ -140,7 +127,7 @@
         }
 
         &_text {
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
             font-size: 0.875rem !important;
             color: #555555 !important;
             display: flex !important;

--- a/src/Pages/Landing/components/auction_info_card/FeaturedInfoCard.scss
+++ b/src/Pages/Landing/components/auction_info_card/FeaturedInfoCard.scss
@@ -22,20 +22,16 @@
         margin: 0.5em 0;
 
         &_bold {
-          font-family: Nunito-Sans-Bold !important;
+          font-weight: 700 !important;
         }
 
         &_timer {
           color: #000 !important;
-          font-family: Nunito-Sans-Bold !important;
+          font-weight: 700 !important;
           font-size: 0.875rem !important;
           font-style: normal;
           font-weight: 700;
           line-height: normal;
-        }
-
-        &_regular {
-          font-family: Nunito-Sans-Regular !important;
         }
 
         &_tag {
@@ -54,7 +50,6 @@
 
       &_price {
         color: rgba(24, 11, 45, 0.5);
-        font-family: Nunito-Sans-Regular !important;
       }
     }
   }

--- a/src/Pages/Landing/components/auction_info_card/OngoingInfoCard.scss
+++ b/src/Pages/Landing/components/auction_info_card/OngoingInfoCard.scss
@@ -17,20 +17,16 @@
     }
 
     &_bold {
-      font-family: Nunito-Sans-Bold !important;
+      font-weight: 700 !important;
     }
 
     &_timer {
       color: #000 !important;
-      font-family: Nunito-Sans-Bold !important;
+      font-weight: 700 !important;
       font-size: 0.875rem !important;
       font-style: normal;
       font-weight: 700;
       line-height: normal;
-    }
-
-    &_regular {
-      font-family: Nunito-Sans-Regular !important;
     }
 
     &_image {
@@ -54,7 +50,6 @@
 
       &_price {
         color: rgba(24, 11, 45, 0.5);
-        font-family: Nunito-Sans-Regular !important;
       }
     }
 

--- a/src/Pages/Landing/components/featured_auctions/FeaturedAuctions.scss
+++ b/src/Pages/Landing/components/featured_auctions/FeaturedAuctions.scss
@@ -1,13 +1,3 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
 .featuredAuctionsContainer {
     background-color: #F2F1F9 !important;
     padding: 3em 0;
@@ -24,7 +14,7 @@
 
     &_title {
         padding: 1em 0;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
     }
 
     &_auctions {

--- a/src/Pages/Landing/components/footer/Footer.scss
+++ b/src/Pages/Landing/components/footer/Footer.scss
@@ -1,19 +1,9 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
-.footer {
+.footer-landing {
     background-color: #180B2D !important;
     padding: 1em 0 2em !important;
 
     &_first {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         margin-top: 0.5em !important;
 
         @media only screen and (min-width: 640px) {
@@ -35,17 +25,14 @@
         padding-bottom: 2em;
 
         &_title {
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
         }
 
-        &_text {
-            font-family: Nunito-Sans-Regular !important;
-        }
     }
 
     &_heading {
         margin: 1em 0 0.5em !important;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
 
         &_special {
             color: #0DD36B !important;
@@ -54,11 +41,7 @@
 
     &_details {
         margin-top: 0.5em !important;
-        font-family: Nunito-Sans-Bold !important;
-
-        &_text {
-            font-family: Nunito-Sans-Regular !important;
-        }
+        font-weight: 700 !important;
     }
 
     &_image_container {
@@ -73,7 +56,7 @@
         gap: 15%;
 
         &_button {
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
         }
     }
 }

--- a/src/Pages/Landing/components/footer/Footer.tsx
+++ b/src/Pages/Landing/components/footer/Footer.tsx
@@ -9,17 +9,30 @@ export const Footer: React.FC = () => {
 
   return (
     <div className="root">
-      <Container className="footer" maxWidth={false} sx={{ marginTop: '3em', marginBottom: '0em' }}>
-        <div className="footer_root">
-          <Grid className="footer_container" container spacing={0}>
+      <Container
+        className="footer-landing"
+        maxWidth={false}
+        sx={{ marginTop: '3em', marginBottom: '0em' }}
+      >
+        <div className="footer-landing_root">
+          <Grid className="footer-landing_container" container spacing={0}>
             <Grid item xs={isTablet ? 12 : 5}>
-              <Typography className="footer_container_title" color={'#FFFFFF'} fontSize="0.875rem">
+              <Typography
+                className="footer-landing_container_title"
+                color={'#FFFFFF'}
+                fontSize="0.875rem"
+              >
                 Decentralised
               </Typography>
-              <Typography className="footer_heading" color={'#FFFFFF'} fontSize="3rem">
-                Equal Access <br></br> for <span className="footer_heading_special">Everyone</span>
+              <Typography className="footer-landing_heading" color={'#FFFFFF'} fontSize="3rem">
+                Equal Access <br></br> for{' '}
+                <span className="footer-landing_heading_special">Everyone</span>
               </Typography>
-              <Typography className="footer_container_text" color={'#FFFFFF'} fontSize="0.75rem">
+              <Typography
+                className="footer-landing_container_text"
+                color={'#FFFFFF'}
+                fontSize="0.75rem"
+              >
                 The go-to fundraising platform for your assets, offering users access to a safe,
                 secure and egalitarian crowdfunding model
               </Typography>
@@ -27,7 +40,7 @@ export const Footer: React.FC = () => {
             <Grid item xs={isTablet ? 0 : 2}></Grid>
             <Grid item xs={isTablet ? 12 : 5}>
               <Typography
-                className="footer_first"
+                className="footer-landing_first"
                 color={'#0DD36B'}
                 fontSize="3rem"
                 textAlign={'right'}
@@ -35,7 +48,7 @@ export const Footer: React.FC = () => {
                 Multiple
               </Typography>
               <Typography
-                className="footer_details_text"
+                className="footer-landing_details_text"
                 color={'#FFFFFF'}
                 fontSize="0.75rem"
                 textAlign={'right'}
@@ -43,7 +56,7 @@ export const Footer: React.FC = () => {
                 EVM Chains
               </Typography>
               <Typography
-                className="footer_details"
+                className="footer-landing_details"
                 color={'#0DD36B'}
                 fontSize="3rem"
                 textAlign={'right'}
@@ -51,7 +64,7 @@ export const Footer: React.FC = () => {
                 Accessible
               </Typography>
               <Typography
-                className="footer_details_text"
+                className="footer-landing_details_text"
                 color={'#FFFFFF'}
                 fontSize="0.75rem"
                 textAlign={'right'}
@@ -59,7 +72,7 @@ export const Footer: React.FC = () => {
                 User Interface
               </Typography>
               <Typography
-                className="footer_details"
+                className="footer-landing_details"
                 color={'#0DD36B'}
                 fontSize="3rem"
                 textAlign={'right'}
@@ -67,7 +80,7 @@ export const Footer: React.FC = () => {
                 Transparent
               </Typography>
               <Typography
-                className="footer_details_text"
+                className="footer-landing_details_text"
                 color={'#FFFFFF'}
                 fontSize="0.75rem"
                 textAlign={'right'}

--- a/src/Pages/Landing/components/hero/Hero.scss
+++ b/src/Pages/Landing/components/hero/Hero.scss
@@ -1,13 +1,3 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
 .hero {
     background-color: #180B2D;
     padding: 1em;
@@ -34,7 +24,8 @@
         }
 
         margin-bottom: 0.5em !important;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
+        font-size: 1.5rem !important;
 
         &_special {
             color: #0DD36B !important;
@@ -53,7 +44,6 @@
             width: 45%;
         }
 
-        font-family: Nunito-Sans-Regular !important;
     }
 
     &_container {
@@ -61,7 +51,7 @@
     }
 
     &_heading-2 {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
     }
 
     &_button {
@@ -70,7 +60,7 @@
         border-radius: 1.5em;
         padding: 0.75em 1em;
         background-color: transparent;
-        font-family: Nunito-Sans-Bold;
+        font-weight: 700 !important;
         font-size: 0.75rem;
         color: #FFF;
         background-color: #8B8596;
@@ -98,12 +88,8 @@
         border: none !important;
         border-radius: 0.5em !important;
 
-        &_content {
-            font-family: Nunito-Sans-Regular !important;
-        }
-
         &_title {
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
         }
     }
 

--- a/src/Pages/Landing/components/hero/Hero.tsx
+++ b/src/Pages/Landing/components/hero/Hero.tsx
@@ -51,7 +51,7 @@ export const Hero: React.FC = () => {
             <div>
               <button className="hero_button" onClick={navigateToDocs}>
                 <div className="hero_button_root">
-                  Read the docs
+                  <Typography variant="inherit">Read the docs</Typography>
                   <ArrowForwardIosIcon fontSize="small" />
                 </div>
               </button>

--- a/src/Pages/Landing/components/ongoing_auctions/OngoingAuctions.scss
+++ b/src/Pages/Landing/components/ongoing_auctions/OngoingAuctions.scss
@@ -1,13 +1,3 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
 .ongoing-auctions {
     background-color: #FFFFFF !important;
     padding: 3em 0 2em;
@@ -19,7 +9,7 @@
 
     &_title {
         padding: 1em 0;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
     }
 
     &_more {
@@ -27,7 +17,7 @@
         justify-content: end;
 
         &_button {
-            font-family: Nunito-Sans-Bold;
+            font-weight: 700 !important;
             font-size: 0.875rem;
             padding: 1em 3rem;
             background-color: transparent;
@@ -36,6 +26,9 @@
             max-width: 25em;
             margin: 1em 0 2em;
             cursor: pointer;
+            font-style: normal !important;
+            text-transform: none !important;
+            color: #000 !important;
         }
     }
 

--- a/src/Pages/Landing/components/ongoing_auctions/OngoingAuctions.tsx
+++ b/src/Pages/Landing/components/ongoing_auctions/OngoingAuctions.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { Grid, Typography } from '@mui/material'
+import { Button, Grid, Typography } from '@mui/material'
 import { Container } from '@mui/system'
 
 import { routes } from '../../../../components/navigation/Routes/constants'
@@ -38,9 +38,13 @@ export const OngoingAuctions: React.FC = () => {
           ))}
         </Grid>
         <div className="ongoing-auctions_more">
-          <button className="ongoing-auctions_more_button" onClick={navigateToAllAuctions}>
+          <Button
+            className="ongoing-auctions_more_button"
+            onClick={navigateToAllAuctions}
+            variant="outlined"
+          >
             View More
-          </button>
+          </Button>
         </div>
       </div>
     </Container>

--- a/src/Pages/PrivateAuctionSigner/index.scss
+++ b/src/Pages/PrivateAuctionSigner/index.scss
@@ -1,13 +1,3 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
 .auction-signer {
     background-color: #F9F9FA;
     padding: 2em 1em;
@@ -19,7 +9,7 @@
     }
 
     &_title {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 0.875rem !important;
         color: #000000 !important;
     }
@@ -59,7 +49,7 @@
             border: none;
             height: 3em;
             font-size: 0.875rem;
-            font-family: Nunito-Sans-Bold;
+            font-weight: 700 !important;
             margin-top: 0.5em;
             cursor: pointer;
             
@@ -101,12 +91,11 @@
 
                 &_id {
                     font-size: 0.875rem !important;
-                    font-family: Nunito-Sans-Bold !important;
+                    font-weight: 700 !important;
                 }
 
                 &_text {
                     font-size: 0.875rem !important;
-                    font-family: Nunito-Sans-Regular !important;
                 }
             }
         }
@@ -126,7 +115,7 @@
 
             &_title {
                 font-size: 0.875rem !important;
-                font-family: Nunito-Sans-Bold !important;
+                font-weight: 700 !important;
             }
 
             &_rows {
@@ -137,7 +126,6 @@
             &_entry {
                 padding: 1.5em 0;
                 font-size: 0.875rem !important;
-                font-family: Nunito-Sans-Regular !important;
             }
         }
     }
@@ -149,18 +137,15 @@
 
 .MuiOutlinedInput-input {
     color: #5940c1 !important;
-    font-family: Nunito-Sans-Regular !important;
     font-size: 0.875rem !important;
 }
 
 .MuiMenuItem-root {
     color: #5940c1 !important;
-    font-family: Nunito-Sans-Regular !important;
     font-size: 0.875rem !important;
 }
 
 .MuiInputLabel-root {
     color: #5940c1 !important;
-    font-family: Nunito-Sans-Regular !important;
     font-size: 0.875rem !important;
 }

--- a/src/Pages/TermsAndConditions/index.scss
+++ b/src/Pages/TermsAndConditions/index.scss
@@ -1,26 +1,15 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
 .tc {
     background-color: #FFFFFF;
     padding: 2em 10% 4em;
     flex-grow: 1;
 
     &_title {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 1.75rem !important;
         margin-bottom: 0.25em !important;
     }
 
     &_text {
-        font-family: Nunito-Sans-Regular !important;
         font-size: 0.875rem !important;
         margin-top: 0.25em !important;
     }
@@ -30,7 +19,7 @@
     }
 
     &_sub-title {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         color: #5940C1 !important;
     }
 
@@ -40,6 +29,6 @@
 
     &_link {
         color: #5940C1 !important;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
     }
 }

--- a/src/components/auctions/AllAuctions/AllAuctions.scss
+++ b/src/components/auctions/AllAuctions/AllAuctions.scss
@@ -1,13 +1,3 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
 .all_auctions {
   &_root {
     max-width: 65em;
@@ -16,7 +6,7 @@
 
   &_title {
       padding: 1em 0;
-      font-family: Nunito-Sans-Bold !important;
+      font-weight: 700;
   }
 
   &_inner_container {

--- a/src/components/common/NetworkSelect/index.scss
+++ b/src/components/common/NetworkSelect/index.scss
@@ -3,7 +3,7 @@
   border-radius: 1rem;
   border: solid #5940c1 1px;
   color: #5940c1;
-  font-family: Nunito-Sans-Bold;
+  font-weight: 700 !important;
   font-size: 0.875rem;
   background-color: transparent;
   cursor: pointer;

--- a/src/components/common/info_card/InfoCard.scss
+++ b/src/components/common/info_card/InfoCard.scss
@@ -9,7 +9,6 @@
     &_heading {
         color: #373737;
         text-align: justify;
-        font-family: Nunito-Sans-Regular !important;
         font-size: 0.875em !important;
         font-style: normal;
         line-height: normal;
@@ -21,7 +20,7 @@
     &_stat {
         color: #180B2D;
         text-align: justify;
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         font-size: 1.75em !important;
         font-style: normal;
         line-height: normal;

--- a/src/components/common/table/Row/Row.scss
+++ b/src/components/common/table/Row/Row.scss
@@ -17,7 +17,7 @@
     align-items: center;
     color: #000;
     font-size: 0.875rem !important;
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
     font-style: normal;
     line-height: normal;
   }

--- a/src/components/common/table/StyledCell/StyledCell.scss
+++ b/src/components/common/table/StyledCell/StyledCell.scss
@@ -3,7 +3,7 @@
   align-items: center;
   color: #000;
   font-size: 0.875rem !important;
-  font-family: Nunito-Sans-Bold !important;
+  font-weight: 700 !important;
   font-style: normal;
   line-height: normal;
   > *:first-child {

--- a/src/components/common/token/UnregisteredToken/img/IconUnregistered.tsx
+++ b/src/components/common/token/UnregisteredToken/img/IconUnregistered.tsx
@@ -22,7 +22,7 @@ export const IconUnregistered: React.FC<{ className?: string }> = (props) => {
       </g>
       <text
         fill="#2B1759"
-        fontFamily="Nunito-Sans-Bold, Averta ☞"
+        fontFamily="Nunito Sans, Averta ☞"
         fontSize="50px"
         fontWeight="700"
         transform="translate(2.5 7.535) translate(34.5 48.465)"

--- a/src/components/create-auction/ConfirmationModalContent/index.scss
+++ b/src/components/create-auction/ConfirmationModalContent/index.scss
@@ -1,3 +1,3 @@
 .modal_details_text {
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
 }

--- a/src/components/create-auction/SubmitAuctionButton/index.scss
+++ b/src/components/create-auction/SubmitAuctionButton/index.scss
@@ -5,7 +5,7 @@
     border: solid #5940c1 1px;
     background-color: #5940c1;
     color: #ffffff;
-    font-family: Nunito-Sans-Bold;
+    font-weight: 700 !important;
     font-size: 0.875rem;
     width: fit-content;
     margin-left: auto;

--- a/src/components/form/Input/index.scss
+++ b/src/components/form/Input/index.scss
@@ -2,7 +2,6 @@
   &_wrapper {
     color: #373737 !important;
     font-size: 0.875rem !important;
-    font-family: Nunito-Sans-Regular !important;
     display: flex;
     align-items: flex-start;
     width: 100%;

--- a/src/components/form/SwitchInput/index.scss
+++ b/src/components/form/SwitchInput/index.scss
@@ -1,6 +1,6 @@
 .switch-input {
   &_title {
-    font-family: Nunito-Sans-Bold !important;
+    font-weight: 700 !important;
     font-size: 0.875rem !important;
     display: flex !important;
     gap: 0.5em !important;

--- a/src/components/form/TextInput/index.scss
+++ b/src/components/form/TextInput/index.scss
@@ -1,7 +1,6 @@
 .text-input {
   color: #373737 !important;
   font-size: 0.875rem !important;
-  font-family: Nunito-Sans-Regular !important;
   margin-bottom: 1.5rem;
 
   &_error {

--- a/src/components/navigation/NavBarLink/NavBarLink.scss
+++ b/src/components/navigation/NavBarLink/NavBarLink.scss
@@ -7,7 +7,7 @@
   display: inline-block;
   position: relative;
   padding-bottom: 0.25rem;
-  font-family: Nunito-Sans-Bold !important;
+  font-weight: 700 !important;
 
   padding: 1em 2em;
   border-radius: 0.675rem;

--- a/src/components/navigation/footer/Footer.scss
+++ b/src/components/navigation/footer/Footer.scss
@@ -1,24 +1,18 @@
-@font-face {
-    font-family: Nunito-Sans-Bold;
-    src: url("../../../assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
-@font-face {
-    font-family: Nunito-Sans-Regular;
-    src: url("../../../assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
 .footer {
     background-color: #180B2D !important;
-    padding: 1em 0 0 !important;
+    max-width: 65em !important;
+    display: flex !important;
+    justify-content: flex-start !important;
 
     &_navbar {
-        display: flex;
-        margin-top: 1em;
+        display: flex !important;
+        margin: 1em auto 0 0 !important;
         text-decoration: none !important;
-        font-family: Nunito-Sans-Regular !important;
         color: #FFFFFF !important;
         font-size: 0.75rem !important;
+
+        padding: 0.25rem 0.5rem !important;
+        border-radius: 0.5em !important;
 
         &:hover {
             background-color: #2B1759;
@@ -34,17 +28,22 @@
         width: 100% !important;
         margin: 0 auto !important;
     }
-
     &_item {
         margin-bottom: 2em !important;
+        display: flex !important;
+        justify-content: flex-start !important;
+    }
+
+    &_links {
+        flex-direction: column !important;
     }
 
     &_title {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
         color: #FFFFFF !important;
         font-size: 0.75rem !important;
+        padding: 0.25rem 0.5rem !important;
     }
-
     &_socials {
         display: flex !important;
         gap: 1.5em !important;

--- a/src/components/navigation/footer/Footer.tsx
+++ b/src/components/navigation/footer/Footer.tsx
@@ -31,7 +31,12 @@ export const Footer: React.FC = () => {
   const isMobile = useMediaQuery('(max-width:800px)')
 
   return (
-    <div className="root" style={{ paddingTop: '2em' }}>
+    <div
+      className="root"
+      style={{
+        paddingTop: '2em',
+      }}
+    >
       <Container className="footer footer_bottom" maxWidth="xl">
         <Grid className="footer_container" container spacing={0}>
           <Grid className="footer_item" item xs={isMobile ? 12 : 3}>
@@ -39,12 +44,12 @@ export const Footer: React.FC = () => {
               <img className="footer_image" src={Logo} />
             </Link>
           </Grid>
-          <Grid className="footer_item" item xs={isMobile ? 12 : 3}>
+          <Grid className="footer_item footer_links" item xs={isMobile ? 12 : 3}>
             <Typography className="footer_title">Auction</Typography>
             <FooterNavBarLink name="Auction List" path={routes.auctionList.path} />
             <FooterNavBarLink name="Create Auction" path={routes.createAuction.path} />
           </Grid>
-          <Grid className="footer_item" item xs={isMobile ? 12 : 3}>
+          <Grid className="footer_item footer_links" item xs={isMobile ? 12 : 3}>
             <Typography className="footer_title">Resources</Typography>
             <FooterNavBarLink name="Documentation" path={routes.docs.path} />
             <FooterNavBarLink name="Terms & Conditions" path={routes.tc.path} />
@@ -59,7 +64,7 @@ export const Footer: React.FC = () => {
             <a href="https://medium.com/@fairprotocol" rel="noreferrer" target="_blank">
               <img src={Medium} />
             </a>
-            <a href="https://t.me/FairLaunchProtocol" rel="noreferrer" target="_blank">
+            <a href="https://t.me/+B871uCbBU7g2MDA1" rel="noreferrer" target="_blank">
               <img src={Telegram} />
             </a>
           </Grid>

--- a/src/components/navigation/navbar/Navbar.scss
+++ b/src/components/navigation/navbar/Navbar.scss
@@ -22,7 +22,7 @@
 
         &_heading {
             margin: 2em 2em 0 !important;
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
         }
 
         &_button {
@@ -40,7 +40,7 @@
     }
 
     &_heading {
-        font-family: Nunito-Sans-Bold !important;
+        font-weight: 700 !important;
     }
 
     &_button {
@@ -48,7 +48,7 @@
         border-radius: 1.5em;
         padding: 1em;
         background-color: transparent;
-        font-family: Nunito-Sans-Bold;
+        font-weight: 700 !important;
         font-size: 0.75rem;
         color: #FFF;
         background-color: #8B8596;

--- a/src/components/private-auction-signer/AddressList/index.scss
+++ b/src/components/private-auction-signer/AddressList/index.scss
@@ -33,7 +33,7 @@
 
         &_title {
             font-size: 0.875rem !important;
-            font-family: Nunito-Sans-Bold !important;
+            font-weight: 700 !important;
         }
 
         &_rows {
@@ -44,7 +44,6 @@
         &_entry {
             padding: 1.5em 0;
             font-size: 0.875rem !important;
-            font-family: Nunito-Sans-Regular !important;
         }
     }
 }

--- a/src/components/web3/connect_button/ConnectButton.scss
+++ b/src/components/web3/connect_button/ConnectButton.scss
@@ -2,14 +2,17 @@
   border: none;
   border-radius: 1.5em;
   padding: 0.75em 1em;
-  font-family: Nunito-Sans-Bold;
-  font-size: 0.75rem;
   color: #fff;
   background-color: #8b8596;
   cursor: pointer;
 
   &:hover {
     background-color: #2B1759;
+  }
+
+  &_text {
+    font-weight: 700 !important;
+    font-size: 0.75rem !important;
   }
 
   &_root {
@@ -24,7 +27,7 @@
     padding: 0.5em 0.5em; 
     background-color: #0DD36B;
     font-size: 0.75rem;
-    font-family: Nunito-Sans-Bold;
+    font-weight: 700 !important;
     color: #222;
     display: flex;
     flex-direction: row;

--- a/src/components/web3/connect_button/ConnectButton.tsx
+++ b/src/components/web3/connect_button/ConnectButton.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
 
+import { Typography } from '@mui/material'
 import { ChainIcon, ConnectKitButton } from 'connectkit'
 import { useAccount, useBalance, useNetwork, useSwitchNetwork } from 'wagmi'
 
@@ -53,23 +54,25 @@ export const ConnectButton = () => {
                 <div className="connectbutton_connected_icon">
                   <ChainIcon id={chain?.id} />
                 </div>
-                <span>{elipsify(address as string, 4)}</span>
+                <Typography className="connectbutton_text">
+                  {elipsify(address as string, 4)}
+                </Typography>
               </div>
               <span className="vertical_divider" />
               <div className="connectbutton_connected_balance">
-                <span>
+                <Typography className="connectbutton_text">
                   {abbreviation(data?.formatted, 6)} {data?.symbol}
-                </span>
+                </Typography>
               </div>
             </button>
           )
         }
         return (
           <button className="connectbutton" onClick={() => connectWallet(show as () => void)}>
-            <div className="connectbutton_root">
+            <Typography className="connectbutton_root connectbutton_text">
               Connect Wallet
               <ChevronRight />
-            </div>
+            </Typography>
           </button>
         )
       }}

--- a/src/index.css
+++ b/src/index.css
@@ -1,27 +1,7 @@
-@font-face {
-  font-family: Nunito-Sans-Light;
-  src: url("./assets/fonts/Nunito-Sans/NunitoSans-Light.ttf") format("truetype"),
-}
-
-@font-face {
-  font-family: Nunito-Sans-Regular;
-  src: url("./assets/fonts/Nunito-Sans/NunitoSans.ttf") format("truetype"),
-}
-
-@font-face {
-  font-family: Nunito-Sans-Medium;
-  src: url("./assets/fonts/Nunito-Sans/NunitoSans-Medium.ttf") format("truetype"),
-}
-
-@font-face {
-  font-family: Nunito-Sans-Bold;
-  src: url("./assets/fonts/Nunito-Sans/NunitoSans-Bold.ttf") format("truetype"),
-}
-
 body {
   margin: 0;
   /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
-  font-family: "Nunito-Sans-Regular";
+  font-family: "Nunito Sans", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import './polyfills'
 
 import React from 'react'
 
+import { ThemeProvider } from '@mui/system'
 import { LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { ConnectKitProvider } from 'connectkit'
@@ -14,7 +15,9 @@ import { WagmiConfig } from 'wagmi'
 import App from './Pages/App'
 import { config } from './connectors'
 import store from './state'
+import { theme } from './theme/'
 import './index.css'
+import 'unfonts.css'
 
 dayjs.extend(relativeTime)
 
@@ -26,7 +29,9 @@ root.render(
       <ConnectKitProvider debugMode>
         <Provider store={store}>
           <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <App />
+            <ThemeProvider theme={theme}>
+              <App />
+            </ThemeProvider>
           </LocalizationProvider>
         </Provider>
       </ConnectKitProvider>

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -25,11 +25,13 @@ const themeOptions: ThemeOptions = {
     },
     success: {
       main: '#0dd36b',
+      light: '#3ddb88',
+      dark: '#09934a',
     },
     divider: '#b9b0eb',
   },
   typography: {
-    fontFamily: 'Nunito-Sans-Regular',
+    fontFamily: ['Nunito Sans', 'sans-serif', '-apple-system', 'Roboto'].join(','),
   },
   spacing: 8,
   shape: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "downlevelIteration": true,
     "isolatedModules": true,
     "noEmit": true,
-    "types": ["vite-plugin-svgr/client"],
+    "types": ["vite-plugin-svgr/client", "unplugin-fonts/client"],
     "jsx": "react-jsx"
   },
   "exclude": ["node_modules", "cypress"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react'
+import Unfonts from 'unplugin-fonts/vite'
 import { defineConfig } from 'vite'
 import svgr from 'vite-plugin-svgr'
 
@@ -25,6 +26,33 @@ export default () => {
         src: '/src',
       },
     },
-    plugins: [react(), svgr()],
+    plugins: [
+      react(),
+      svgr(),
+      Unfonts({
+        custom: {
+          display: 'swap',
+          families: [
+            {
+              name: 'Nunito Sans',
+              local: 'Nunito Sans',
+              src: './src/assets/fonts/Nunito-Sans/*.ttf',
+              transform(font) {
+                if (font.basename === 'NunitoSans-Bold') {
+                  font.weight = 700
+                }
+                if (font.basename === 'NunitoSans-Light') {
+                  font.weight = 400
+                }
+                if (font.basename === 'NunitoSans-Medium') {
+                  font.weight = 600
+                }
+                return font
+              },
+            },
+          ],
+        },
+      }),
+    ],
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2497,6 +2497,11 @@ acorn@^7.0.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
+acorn@^8.10.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
+
 acorn@^8.8.2, acorn@^8.9.0:
   version "8.9.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.9.0.tgz#78a16e3b2bcc198c10822786fa6679e245db5b59"
@@ -2930,7 +2935,7 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-"chokidar@>=3.0.0 <4.0.0":
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -6370,6 +6375,24 @@ unicode-trie@^2.0.0:
     pako "^0.2.5"
     tiny-inflate "^1.0.0"
 
+unplugin-fonts@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/unplugin-fonts/-/unplugin-fonts-1.0.3.tgz#5b85f29f227305f085d382a42f6983317db19621"
+  integrity sha512-6Wq0SMhMznUx7DTkqr/ogCvWg2vFSCApHmhUcUISxqfnuME2B/KRLa6+bWyX3sbPNhYsW4zI7jvUkkmIumwenw==
+  dependencies:
+    fast-glob "^3.2.12"
+    unplugin "^1.3.1"
+
+unplugin@^1.3.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-1.5.0.tgz#8938ae84defe62afc7757df9ca05d27160f6c20c"
+  integrity sha512-9ZdRwbh/4gcm1JTOkp9lAkIDrtOyOxgHmY7cjuwI8L/2RTikMcVG25GsZwNAgRuap3iDw2jeq7eoqtAsz5rW3A==
+  dependencies:
+    acorn "^8.10.0"
+    chokidar "^3.5.3"
+    webpack-sources "^3.2.3"
+    webpack-virtual-modules "^0.5.0"
+
 update-browserslist-db@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz#9a2a641ad2907ae7b3616506f4b977851db5b940"
@@ -6518,6 +6541,16 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+webpack-sources@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
+
+webpack-virtual-modules@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz#362f14738a56dae107937ab98ea7062e8bdd3b6c"
+  integrity sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Explanation

* Add Nunito Sans as the default fault throughout app
* Remove occurrence of Nunito-Sans in all style files

## How was this solved?
Used the library [unplug-fonts](https://github.com/cssninjaStudio/unplugin-fonts) to help in loading the font files via the vite loader. Post this, define the font in the index.scss file and the `theme` object. 

## Pre-merge author checklist

- [ ] I've clearly explained:
  - [x] What problem this PR is solving
  - [ ] How this problem was solved
  - [ ] How reviewers can test my changes
- [ ] Sufficient automated test coverage has been added